### PR TITLE
Stay in control mode when cursor exits the screen

### DIFF
--- a/rmf_site_editor/src/interaction/camera_controls/cursor.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/cursor.rs
@@ -55,6 +55,24 @@ impl Default for CursorCommand {
     }
 }
 
+impl CursorCommand {
+    pub fn take_translation_delta(&mut self) -> Vec3 {
+        std::mem::replace(&mut self.translation_delta, Vec3::ZERO)
+    }
+
+    pub fn take_rotation_delta(&mut self) -> Quat {
+        std::mem::replace(&mut self.rotation_delta, Quat::IDENTITY)
+    }
+
+    pub fn take_scale_delta(&mut self) -> f32 {
+        std::mem::replace(&mut self.scale_delta, 0.0)
+    }
+
+    pub fn take_fov_delta(&mut self) -> f32 {
+        std::mem::replace(&mut self.fov_delta, 0.0)
+    }
+}
+
 pub fn update_cursor_command(
     mut camera_controls: ResMut<CameraControls>,
     mut cursor_command: ResMut<CursorCommand>,
@@ -69,7 +87,6 @@ pub fn update_cursor_command(
     if let Ok(window) = primary_windows.get_single() {
         // Return if cursor not within window
         if window.cursor_position().is_none() {
-            *cursor_command = CursorCommand::default();
             return;
         }
 

--- a/rmf_site_editor/src/interaction/camera_controls/keyboard.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/keyboard.rs
@@ -61,6 +61,24 @@ impl Default for KeyboardCommand {
     }
 }
 
+impl KeyboardCommand {
+    pub fn take_translation_delta(&mut self) -> Vec3 {
+        std::mem::replace(&mut self.translation_delta, Vec3::ZERO)
+    }
+
+    pub fn take_rotation_delta(&mut self) -> Quat {
+        std::mem::replace(&mut self.rotation_delta, Quat::IDENTITY)
+    }
+
+    pub fn take_scale_delta(&mut self) -> f32 {
+        std::mem::replace(&mut self.scale_delta, 0.0)
+    }
+
+    pub fn take_fov_delta(&mut self) -> f32 {
+        std::mem::replace(&mut self.fov_delta, 0.0)
+    }
+}
+
 pub fn update_keyboard_command(
     mut camera_controls: ResMut<CameraControls>,
     mut keyboard_command: ResMut<KeyboardCommand>,

--- a/rmf_site_editor/src/interaction/camera_controls/mod.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/mod.rs
@@ -403,8 +403,8 @@ impl FromWorld for CameraControls {
 }
 
 fn camera_controls(
-    cursor_command: ResMut<CursorCommand>,
-    keyboard_command: ResMut<KeyboardCommand>,
+    mut cursor_command: ResMut<CursorCommand>,
+    mut keyboard_command: ResMut<KeyboardCommand>,
     mut controls: ResMut<CameraControls>,
     mut cameras: Query<(&mut Projection, &mut Transform)>,
     mut bevy_cameras: Query<&mut Camera>,
@@ -438,15 +438,15 @@ fn camera_controls(
     if cursor_command.command_type != CameraCommandType::Inactive
         && cursor_command.command_type != CameraCommandType::HoldOrbitSelection
     {
-        translation_delta = cursor_command.translation_delta;
-        rotation_delta = cursor_command.rotation_delta;
-        fov_delta = cursor_command.fov_delta;
-        scale_delta = cursor_command.scale_delta;
+        translation_delta = cursor_command.take_translation_delta();
+        rotation_delta = cursor_command.take_rotation_delta();
+        fov_delta = cursor_command.take_fov_delta();
+        scale_delta = cursor_command.take_scale_delta();
     } else {
-        translation_delta = keyboard_command.translation_delta;
-        rotation_delta = keyboard_command.rotation_delta;
-        fov_delta = keyboard_command.fov_delta;
-        scale_delta = keyboard_command.scale_delta;
+        translation_delta = keyboard_command.take_translation_delta();
+        rotation_delta = keyboard_command.take_rotation_delta();
+        fov_delta = keyboard_command.take_fov_delta();
+        scale_delta = keyboard_command.take_scale_delta();
     }
 
     if controls.mode() == ProjectionMode::Perspective {


### PR DESCRIPTION
Currently if the cursor moves off screen while panning or orbiting, the application will unceremoniously drop out of pan/orbit mode. This can be jarring as a user because it means a small slip of the cursor can create a discontinuity in the control of the view.

This PR removes the line that drops us out of the control mode, and it also tweaks the way that deltas are handled so that we have a reasonable continuity when the cursor leaves the screen.